### PR TITLE
[fix] prohbit creation of duplicate email

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,18 @@ const users = [];
 // Create a new user
 router.post('/users', (ctx) => {
   const newUser = ctx.request.body;
-  // insert new user
-  newUser.id = users.length + 1;
-  users.push(newUser);
-  ctx.body = { message: 'User created', user: newUser };
+  // don't allow duplicate user [name, email]
+  const duplicateUser = users.find((user) => user.email === newUser.email);
+  if (duplicateUser) {
+    // duplicate user
+    ctx.status = 409;
+    ctx.body = { message: 'This user already exists' };
+  } else {
+    // insert new user
+    newUser.id = users.length + 1;
+    users.push(newUser);
+    ctx.body = { message: 'User created', user: newUser };
+  }
 });
 
 // Get all users


### PR DESCRIPTION
What are the issues?
- The current creation process doesn't check if a user's email already exists in the database.
- This could lead to making duplicate user accounts, especially with the updated "POST /users" endpoint.
- To avoid this problem, it's important to improve the email verification process during account creation.

What I accomplished?
- Enhanced email verification during account creation to prevent duplicates, particularly with the updated 'POST /users' endpoint. Improved data integrity and user experience.
